### PR TITLE
Add virtual environment setup to setup_env.sh

### DIFF
--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -34,14 +34,30 @@ else
     info "external/ctm already exists; skipping clone."
 fi
 
-# Install Python requirements
-info "Installing Python requirements..."
-python3 -m pip install --upgrade pip
-python3 -m pip install -r requirements.txt
+# Python virtual environment setup
+if [ ! -d venv ]; then
+    info "Creating Python virtual environment in ./venv ..."
+    python3 -m venv venv
+else
+    info "Python virtual environment (venv) already exists."
+fi
 
-# Install LeRobot and CTM in editable mode
-info "Installing LeRobot and CTM in editable mode..."
-python3 -m pip install -e external/lerobot
-python3 -m pip install -e external/ctm
+# Activate the virtual environment
+# shellcheck disable=SC1091
+source venv/bin/activate
+info "Activated virtual environment."
 
-success "Environment setup complete! You can now develop and run experiments."
+# Upgrade pip and install Python requirements
+info "Installing Python requirements inside virtual environment..."
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# Install LeRobot and CTM in editable mode inside venv
+info "Installing LeRobot and CTM in editable mode inside venv..."
+pip install -e external/lerobot
+pip install -e external/ctm
+
+success "Environment setup complete! Virtual environment is active."
+echo ""
+echo "To deactivate the environment, run: deactivate"
+echo "To activate again later, run: source venv/bin/activate"


### PR DESCRIPTION
This pull request modifies the `setup_env.sh` script to create and activate a Python virtual environment before installing dependencies. This change addresses issue #3 by ensuring that Python packages are installed in an isolated environment, which prevents conflicts with system-wide packages and makes the project more reproducible for contributors.

### Key Changes:
- Added logic to check for an existing `venv` directory and create it if missing.
- Included command to activate the virtual environment prior to executing `pip install` commands.
- Updated the install commands to use `pip` within the activated virtual environment.
- Added clear instructions for deactivating the environment and instructions for reactivating it.

These enhancements improve the onboarding experience for new contributors and ensure a consistent and isolated development setup.

---

> This pull request was co-created with Cosine Genie

Original Task: [push-T_memory/r0pnsyu0bw2b](https://cosine.sh/cg1w4jhdz0nu/push-T_memory/task/r0pnsyu0bw2b)
Author: Alex P
